### PR TITLE
Add NOT NULL constraints to DB fields

### DIFF
--- a/db/setup.sql
+++ b/db/setup.sql
@@ -7,13 +7,13 @@ CREATE TABLE mods (
 
 CREATE TABLE mods_access (
     mod_id TEXT NOT NULL,
-    user_id INT NOT NULL DEFAULT 1,
+    user_id INT NOT NULL,
     FOREIGN KEY(mod_id) REFERENCES mods(id),
     FOREIGN KEY(user_id) REFERENCES modders(user_id)
 );
 
 CREATE TABLE modders (
-    user_id INT NOT NULL DEFAULT 1 PRIMARY KEY,
+    user_id INT NOT NULL PRIMARY KEY,
     name TEXT NOT NULL DEFAULT 'Developer',
     about_me TEXT
 );

--- a/db/setup.sql
+++ b/db/setup.sql
@@ -1,20 +1,19 @@
-
 CREATE TABLE mods (
-    id TEXT PRIMARY KEY,
-    name TEXT,
-    developer TEXT,
+    id TEXT NOT NULL PRIMARY KEY,
+    name TEXT NOT NULL DEFAULT 'My Mod',
+    developer TEXT NOT NULL DEFAULT 'Developer',
     download_url TEXT
 );
 
 CREATE TABLE mods_access (
-    mod_id TEXT,
-    user_id INT,
+    mod_id TEXT NOT NULL,
+    user_id INT NOT NULL DEFAULT 1,
     FOREIGN KEY(mod_id) REFERENCES mods(id),
     FOREIGN KEY(user_id) REFERENCES modders(user_id)
 );
 
 CREATE TABLE modders (
-    user_id INT PRIMARY KEY,
-    name TEXT,
+    user_id INT NOT NULL DEFAULT 1 PRIMARY KEY,
+    name TEXT NOT NULL DEFAULT 'Developer',
     about_me TEXT
 );

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,9 +30,9 @@ impl ResponseError for Error {}
 
 #[derive(Serialize)]
 struct Mod {
-    id: Option<String>,
-    name: Option<String>,
-    developer: Option<String>,
+    id: String,
+    name: String,
+    developer: String,
     download_url: Option<String>,
 }
 


### PR DESCRIPTION
Some DB fields on the SQLite database should not be `NULL`. I've added `NOT NULL` and defaults just in case.
This way, in `src/main.rs`, you wont have to do Option<Type> for those fields that have `NOT NULL ` constraints.

Let me know if there needs to be any changes in this PR.