### PR TITLE
Allow developers/admins to fetch unverified mods

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -363,7 +363,19 @@ paths:
       parameters:
         - $ref: "#/components/parameters/ModID"
         - $ref: "#/components/parameters/ModVersion"
+        - name: no_redirect
+          in: query
+          schema:
+            type: boolean
+            default: false
+          description: Return the mod download link instead of a redirect
       responses:
+        "200":
+          description: The direct download link for the mod, when no_redirect is enabled
+          content:
+            application/json:
+              schema:
+                type: string
         "302":
           description: Redirect to the actual mod download link
         "404":
@@ -378,7 +390,19 @@ paths:
       summary: Download the latest version of a mod
       parameters:
         - $ref: "#/components/parameters/ModID"
+        - name: no_redirect
+          in: query
+          schema:
+            type: boolean
+            default: false
+          description: Returns the URL of the mod download instead of a redirect
       responses:
+        "200":
+          description: Contains the mod direct download when no_redirect is enabled
+          content:
+            application/json:
+              schema:
+                type: string
         "302":
           description: Redirect to the actual mod download link
         "404":

--- a/openapi.yml
+++ b/openapi.yml
@@ -715,6 +715,8 @@ components:
             - $ref: "#/components/schemas/GDVersionObject"
         mod_id:
           $ref: "#/components/schemas/ModID"
+        validated:
+          type: boolean
 
     ModDeveloper:
       type: object

--- a/src/endpoints/developers.rs
+++ b/src/endpoints/developers.rs
@@ -71,7 +71,7 @@ pub async fn add_developer_to_mod(
         Some(d) => d,
     };
 
-    if (Mod::get_one(&path.id, &mut transaction).await?).is_none() {
+    if (Mod::get_one(&path.id, true, &mut transaction).await?).is_none() {
         return Err(ApiError::NotFound(format!("Mod id {} not found", path.id)));
     }
 
@@ -110,7 +110,7 @@ pub async fn remove_dev_from_mod(
         }
         Some(d) => d,
     };
-    if (Mod::get_one(&path.id, &mut transaction).await?).is_none() {
+    if (Mod::get_one(&path.id, true, &mut transaction).await?).is_none() {
         return Err(ApiError::NotFound(format!("Mod id {} not found", path.id)));
     }
 

--- a/src/types/models/mod_entity.rs
+++ b/src/types/models/mod_entity.rs
@@ -89,6 +89,7 @@ struct ModRecordGetOne {
     changelog: Option<String>,
     created_at: DateTime<Utc>,
     updated_at: DateTime<Utc>,
+    mod_version_validated: bool
 }
 
 impl Mod {
@@ -469,7 +470,7 @@ impl Mod {
             "SELECT
                 m.id, m.repository, m.about, m.changelog, m.featured, m.download_count as mod_download_count, m.created_at, m.updated_at,
                 mv.id as version_id, mv.name, mv.description, mv.version, mv.download_link, mv.download_count as mod_version_download_count,
-                mv.hash, mv.geode, mv.early_load, mv.api, mv.mod_id
+                mv.hash, mv.geode, mv.early_load, mv.api, mv.mod_id, mv.validated as mod_version_validated
             FROM mods m
             INNER JOIN mod_versions mv ON m.id = mv.mod_id
             WHERE m.id = $1 AND mv.validated = true",
@@ -505,6 +506,7 @@ impl Mod {
                 },
                 dependencies: None,
                 incompatibilities: None,
+                validated: x.mod_version_validated
             })
             .collect();
         let ids = versions.iter().map(|x| x.id).collect();

--- a/src/types/models/mod_version.rs
+++ b/src/types/models/mod_version.rs
@@ -32,6 +32,7 @@ pub struct ModVersion {
     pub gd: DetailedGDVersion,
     pub dependencies: Option<Vec<ResponseDependency>>,
     pub incompatibilities: Option<Vec<ResponseIncompatibility>>,
+    pub validated: bool,
 }
 
 #[derive(sqlx::FromRow)]
@@ -47,6 +48,7 @@ struct ModVersionGetOne {
     early_load: bool,
     api: bool,
     mod_id: String,
+    validated: bool,
 }
 
 impl ModVersionGetOne {
@@ -73,6 +75,7 @@ impl ModVersionGetOne {
             },
             dependencies: None,
             incompatibilities: None,
+            validated: self.validated,
         }
     }
 }
@@ -162,7 +165,7 @@ impl ModVersion {
         let mut query_builder: QueryBuilder<Postgres> = QueryBuilder::new(
             r#"SELECT DISTINCT
             mv.name, mv.id, mv.description, mv.version, mv.download_link, mv.hash, mv.geode, mv.download_count,
-            mv.early_load, mv.api, mv.mod_id FROM mod_versions mv 
+            mv.early_load, mv.api, mv.mod_id, mv.validated FROM mod_versions mv
             WHERE mv.validated = false AND mv.mod_id IN ("#,
         );
         let mut separated = query_builder.separated(",");
@@ -359,7 +362,7 @@ impl ModVersion {
             ModVersionGetOne,
             "SELECT
             mv.id, mv.name, mv.description, mv.version, mv.download_link, mv.download_count,
-            mv.hash, mv.geode, mv.early_load, mv.api, mv.mod_id FROM mod_versions mv
+            mv.hash, mv.geode, mv.early_load, mv.api, mv.mod_id, mv.validated FROM mod_versions mv
             INNER JOIN mods m ON m.id = mv.mod_id
             WHERE mv.mod_id = $1 AND mv.version = $2 AND mv.validated = true",
             id,


### PR DESCRIPTION
This affects the following endpoints, now making it possible for mod owners (and admins) to use them on mods that aren't marked as valid
- GET `/v1/mods/`
- GET `/v1/mods/{id}/logo`
- GET `/v1/mods/{id}/versions/{version}`
- GET `/v1/mods/{id}/versions/{version}/download`
- POST `/v1/mods/{id}/developers`
- DELETE `/v1/mods/{id}/developers/{name}`

This also adds the `validated` attribute to any API that deals with the `ModVersion`, in line with the `SimpleDevModVersion`. It's not required, but it does make handling the authentication needed for the above endpoints a little cleaner

code quality is a little bad though :(