### PR TITLE
Allow readonly tags in mod.json if mod has it serverside

### DIFF
--- a/.sqlx/query-01959e9a4fdc1c6b0d9dbeff80c79a58e0bae2d79af6c2b9e53ead7d9b6e214d.json
+++ b/.sqlx/query-01959e9a4fdc1c6b0d9dbeff80c79a58e0bae2d79af6c2b9e53ead7d9b6e214d.json
@@ -1,0 +1,40 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT DISTINCT\n            t.id,\n            t.name,\n            t.display_name,\n            t.is_readonly\n        FROM mod_tags t\n        INNER JOIN mods_mod_tags mmt ON mmt.tag_id = t.id\n        WHERE t.is_readonly = true\n        AND mmt.mod_id = $1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 1,
+        "name": "name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "display_name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "is_readonly",
+        "type_info": "Bool"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      true,
+      false
+    ]
+  },
+  "hash": "01959e9a4fdc1c6b0d9dbeff80c79a58e0bae2d79af6c2b9e53ead7d9b6e214d"
+}

--- a/src/endpoints/mod_versions.rs
+++ b/src/endpoints/mod_versions.rs
@@ -371,7 +371,7 @@ pub async fn create_version(
         }
         if let Some(tags) = &json.tags {
             if !tags.is_empty() {
-                let tags = mod_tags::parse_tag_list(tags, &mut tx).await?;
+                let tags = mod_tags::parse_tag_list(tags, &the_mod.id, &mut tx).await?;
                 mod_tags::update_for_mod(&the_mod.id, &tags, &mut tx).await?;
             }
         }
@@ -490,7 +490,7 @@ pub async fn update_version(
 
         // Update tags with data from mod.json
         let tags = if let Some(tags) = &json.tags {
-            mod_tags::parse_tag_list(tags, &mut tx).await?
+            mod_tags::parse_tag_list(tags, &the_mod.id, &mut tx).await?
         } else {
             vec![]
         };

--- a/src/endpoints/mods.rs
+++ b/src/endpoints/mods.rs
@@ -198,7 +198,7 @@ pub async fn create(
     }
 
     if let Some(tags) = &json.tags {
-        let tag_list = mod_tags::parse_tag_list(tags, &mut tx).await?;
+        let tag_list = mod_tags::parse_tag_list(tags, &the_mod.id, &mut tx).await?;
         mod_tags::update_for_mod(&the_mod.id, &tag_list, &mut tx).await?;
     }
     if let Some(l) = json.links.clone() {


### PR DESCRIPTION
This will allow mods that have a **readonly** tag to have it in `mod.json` and update without any issues.