### PR TITLE
Add extra validation for user-submitted data

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -915,6 +915,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "deflate64"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1338,6 +1373,7 @@ dependencies = [
  "utoipa",
  "utoipa-swagger-ui",
  "uuid",
+ "validator",
  "zip 7.2.0",
 ]
 
@@ -1700,6 +1736,12 @@ dependencies = [
  "zerotrie",
  "zerovec",
 ]
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
@@ -2443,6 +2485,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "proc-macro-error-attr2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -3948,6 +4012,36 @@ dependencies = [
  "aligned-vec",
  "num-traits",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "validator"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43fb22e1a008ece370ce08a3e9e4447a910e92621bb49b85d6e48a45397e7cfa"
+dependencies = [
+ "idna",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "url",
+ "validator_derive",
+]
+
+[[package]]
+name = "validator_derive"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7df16e474ef958526d1205f6dda359fdfab79d9aa6d54bafcb92dcd07673dca"
+dependencies = [
+ "darling",
+ "once_cell",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,3 +43,4 @@ thiserror = "2.0.12"
 moka = { version = "0.12.13", features = ["future"] }
 utoipa = { version = "5.4.0", features = ["actix_extras", "chrono", "uuid"] }
 utoipa-swagger-ui = { version = "9.0.2", features = ["actix-web"] }
+validator = { version = "0.20.0", features = ["derive"] }

--- a/src/endpoints/developers.rs
+++ b/src/endpoints/developers.rs
@@ -297,9 +297,9 @@ pub async fn update_profile(
         ));
     }
 
-    if json.display_name.len() < 2 {
+    if json.display_name.len() < 2 || json.display_name.len() > 64 {
         return Err(ApiError::BadRequest(
-            "Display name must have more than 1 character".into(),
+            "Display name must be between 2 and 64 characters".into(),
         ));
     }
 

--- a/src/mod_zip.rs
+++ b/src/mod_zip.rs
@@ -6,9 +6,9 @@ use image::codecs::png::PngDecoder;
 use image::codecs::png::PngEncoder;
 use image::{DynamicImage, GenericImageView};
 use image::{ImageEncoder, ImageError};
+use zip::ZipArchive;
 use zip::read::ZipFile;
 use zip::result::ZipError;
-use zip::ZipArchive;
 
 #[derive(thiserror::Error, Debug)]
 pub enum ModZipError {
@@ -28,6 +28,8 @@ pub enum ModZipError {
     ModFileFetchError(#[from] reqwest::Error),
     #[error(".geode file is too large ({0} MB), maximum is {1} MB")]
     ModFileTooLarge(u64, u64),
+    #[error(".geode file is too large after uncompression ({0} MB), maximum is {1} MB")]
+    ModFileTooLargeUncompressed(u64, u64),
     #[error("Invalid mod.json: {0}")]
     InvalidModJson(String),
     #[error("Invalid binaries: {0}")]

--- a/src/types/mod_json.rs
+++ b/src/types/mod_json.rs
@@ -211,8 +211,8 @@ impl ModJson {
 
         if json_file.size() > MAX_MOD_JSON_SIZE {
             return Err(ModZipError::InvalidModJson(format!(
-                "mod.json is too large (max {} bytes)",
-                MAX_MOD_JSON_SIZE
+                "mod.json is too large (max {} MB)",
+                MAX_MOD_JSON_SIZE / 1_000_000
             )));
         }
 
@@ -240,8 +240,8 @@ impl ModJson {
                 } else if file.name().eq("about.md") {
                     if file.size() > MAX_MARKDOWN_FILE_SIZE {
                         return Err(ModZipError::InvalidModJson(format!(
-                            "about.md is too large (max {} bytes)",
-                            MAX_MARKDOWN_FILE_SIZE
+                            "about.md is too large (max {} MB)",
+                            MAX_MARKDOWN_FILE_SIZE / 1_000_000
                         )));
                     }
 
@@ -255,8 +255,8 @@ impl ModJson {
                 } else if file.name().eq("changelog.md") {
                     if file.size() > MAX_MARKDOWN_FILE_SIZE {
                         return Err(ModZipError::InvalidModJson(format!(
-                            "changelog.md is too large (max {} bytes)",
-                            MAX_MARKDOWN_FILE_SIZE
+                            "changelog.md is too large (max {} MB)",
+                            MAX_MARKDOWN_FILE_SIZE / 1_000_000
                         )));
                     }
 

--- a/src/types/mod_json.rs
+++ b/src/types/mod_json.rs
@@ -6,6 +6,7 @@ use regex::Regex;
 use reqwest::Url;
 use semver::Version;
 use serde::Deserialize;
+use validator::{Validate, ValidationError};
 use zip::read::ZipFile;
 
 use crate::mod_zip::{self, ModZipError};
@@ -16,16 +17,29 @@ use super::models::{
     mod_gd_version::DetailedGDVersion,
 };
 
-#[derive(Debug, Deserialize)]
+const MAX_MOD_JSON_SIZE: u64 = 65536; // 64 KB
+const MAX_MARKDOWN_FILE_SIZE: u64 = 1048576; // 1 MB
+const MAX_MOD_ZIP_SIZE: u64 = 1024 * 1024 * 512; // 512 mb
+
+#[derive(Debug, Deserialize, Validate)]
 pub struct ModJson {
+    #[validate(length(max = 32))]
     pub geode: String,
+    #[validate(length(max = 32))]
     pub version: String,
+    #[validate(length(max = 64))]
     pub id: String,
+    #[validate(length(max = 256))]
     pub name: String,
+    #[validate(length(max = 256))]
     pub developer: Option<String>,
+    #[validate(custom(function = "validate_vec_string"))]
     pub developers: Option<Vec<String>>,
+    #[validate(length(max = 512))]
     pub description: Option<String>,
+    #[validate(length(max = 512))]
     pub repository: Option<String>,
+    #[validate(custom(function = "validate_vec_string"))]
     pub tags: Option<Vec<String>>,
     #[serde(default, skip_deserializing)]
     pub windows: bool,
@@ -51,17 +65,22 @@ pub struct ModJson {
     pub gd: DetailedGDVersion,
     #[serde(skip_deserializing, skip_serializing)]
     pub logo: Vec<u8>,
+    #[validate(length(min = 1, max = MAX_MARKDOWN_FILE_SIZE))]
     pub about: Option<String>,
+    #[validate(length(min = 1, max = MAX_MARKDOWN_FILE_SIZE))]
     pub changelog: Option<String>,
     pub dependencies: Option<ModJsonDependencies>,
     pub incompatibilities: Option<ModJsonIncompatibilities>,
     pub links: Option<ModJsonLinks>,
 }
 
-#[derive(Deserialize, Debug, Clone)]
+#[derive(Deserialize, Debug, Clone, Validate)]
 pub struct ModJsonLinks {
+    #[validate(length(max = 512))]
     pub community: Option<String>,
+    #[validate(length(max = 512))]
     pub homepage: Option<String>,
+    #[validate(length(max = 512))]
     pub source: Option<String>,
 }
 
@@ -169,11 +188,33 @@ impl ModJson {
         let hash = sha256::digest(slice);
         let mut archive = mod_zip::bytes_to_ziparchive(file)?;
 
+        // check total size of the zip file
+        let mut total_size: u64 = 0;
+        for i in 0..archive.len() {
+            let file = archive.by_index(i)?;
+            total_size += file.size();
+        }
+
+        if total_size > MAX_MOD_ZIP_SIZE {
+            let size_mb = total_size / 1_000_000;
+            return Err(ModZipError::ModFileTooLargeUncompressed(
+                size_mb,
+                MAX_MOD_ZIP_SIZE / 1_000_000,
+            ));
+        }
+
         let json_file = archive
             .by_name("mod.json")
             .or(Err(ModZipError::InvalidModJson(
                 "No mod.json found in .geode file".into(),
             )))?;
+
+        if json_file.size() > MAX_MOD_JSON_SIZE {
+            return Err(ModZipError::InvalidModJson(format!(
+                "mod.json is too large (max {} bytes)",
+                MAX_MOD_JSON_SIZE
+            )));
+        }
 
         let mut json = serde_json::from_reader::<ZipFile<Cursor<Bytes>>, ModJson>(json_file)
             .inspect_err(|e| log::error!("Failed to parse mod.json: {e}"))?;
@@ -197,6 +238,13 @@ impl ModJson {
                 } else if file.name().ends_with(".android64.so") {
                     json.android64 = true;
                 } else if file.name().eq("about.md") {
+                    if file.size() > MAX_MARKDOWN_FILE_SIZE {
+                        return Err(ModZipError::InvalidModJson(format!(
+                            "about.md is too large (max {} bytes)",
+                            MAX_MARKDOWN_FILE_SIZE
+                        )));
+                    }
+
                     json.about = Some(
                         parse_zip_entry_to_str(&mut file)
                             .inspect_err(|e| log::error!("Failed to parse about.md for mod: {e}"))
@@ -205,6 +253,13 @@ impl ModJson {
                             })?,
                     );
                 } else if file.name().eq("changelog.md") {
+                    if file.size() > MAX_MARKDOWN_FILE_SIZE {
+                        return Err(ModZipError::InvalidModJson(format!(
+                            "changelog.md is too large (max {} bytes)",
+                            MAX_MARKDOWN_FILE_SIZE
+                        )));
+                    }
+
                     json.changelog = Some(
                         parse_zip_entry_to_str(&mut file)
                             .inspect_err(|e| log::error!("Failed to parse changelog.md: {e}"))
@@ -427,6 +482,13 @@ impl ModJson {
     }
 
     pub fn validate(&self) -> Result<(), ModZipError> {
+        if let Err(e) = <Self as Validate>::validate(self) {
+            log::error!("mod.json validation error: {e}");
+            return Err(ModZipError::InvalidModJson(
+                "validation error, likely one or multiple fields are unreasonably long".into(),
+            ));
+        }
+
         let id_regex = Regex::new(r#"^[a-z0-9_\-]+\.[a-z0-9_\-]+$"#).unwrap();
         if !id_regex.is_match(&self.id) {
             return Err(ModZipError::InvalidModJson(format!(
@@ -458,12 +520,6 @@ impl ModJson {
         if self.developer.is_none() && self.developers.is_none() {
             return Err(ModZipError::InvalidModJson(
                 "No developer specified on mod.json".to_string(),
-            ));
-        }
-
-        if self.id.len() > 64 {
-            return Err(ModZipError::InvalidModJson(
-                "Mod id too long (max 64 characters)".to_string(),
             ));
         }
 
@@ -619,4 +675,15 @@ fn check_mac_binary(file: &mut ZipFile<Cursor<Bytes>>) -> Result<(bool, bool), M
         }
     }
     Err(ModZipError::InvalidBinaries("Invalid macOS binary".into()))
+}
+
+fn validate_vec_string(vec: &Vec<String>) -> Result<(), ValidationError> {
+    for s in vec {
+        if s.len() > 256 {
+            return Err(ValidationError::new(
+                "String is too long (max 256 characters)",
+            ));
+        }
+    }
+    Ok(())
 }

--- a/src/types/mod_json.rs
+++ b/src/types/mod_json.rs
@@ -483,10 +483,11 @@ impl ModJson {
 
     pub fn validate(&self) -> Result<(), ModZipError> {
         if let Err(e) = <Self as Validate>::validate(self) {
-            log::error!("mod.json validation error: {e}");
-            return Err(ModZipError::InvalidModJson(
-                "validation error, likely one or multiple fields are unreasonably long".into(),
-            ));
+            log::warn!("mod.json validation error: {e}");
+            let useful_error = extract_validation_error(&e);
+            return Err(ModZipError::InvalidModJson(format!(
+                "validation error: {useful_error}"
+            )));
         }
 
         let id_regex = Regex::new(r#"^[a-z0-9_\-]+\.[a-z0-9_\-]+$"#).unwrap();
@@ -693,4 +694,75 @@ fn validate_vec_string(vec: &Vec<String>) -> Result<(), ValidationError> {
         }
     }
     Ok(())
+}
+
+fn map_field_error(e: &validator::ValidationError) -> String {
+    if let Some(msg) = &e.message {
+        return msg.to_string();
+    }
+
+    match e.code.as_ref() {
+        "length" => {
+            let min = e
+                .params
+                .get("min")
+                .and_then(|v| v.as_u64())
+                .map(|v| v.to_string());
+
+            let max = e
+                .params
+                .get("max")
+                .and_then(|v| v.as_u64())
+                .map(|v| v.to_string());
+
+            match (min, max) {
+                (Some(min), Some(max)) => {
+                    format!("length must be between {min} and {max} characters")
+                }
+                (Some(min), None) => format!("length must be at least {min} characters"),
+                (None, Some(max)) => format!("length must be at most {max} characters"),
+                (None, None) => "invalid length".to_string(),
+            }
+        }
+
+        e => e.to_owned(),
+    }
+}
+
+fn extract_validation_error(e: &validator::ValidationErrors) -> String {
+    use validator::ValidationErrorsKind;
+
+    let mut str_errors = Vec::new();
+
+    for (field, err) in e.errors() {
+        match err {
+            ValidationErrorsKind::Struct(s) => {
+                str_errors.push(format!(
+                    "field '{field}' is invalid ({})",
+                    extract_validation_error(s)
+                ));
+            }
+
+            ValidationErrorsKind::Field(errors) => {
+                let joined = errors
+                    .iter()
+                    .map(map_field_error)
+                    .collect::<Vec<_>>()
+                    .join(", ");
+
+                str_errors.push(format!("field '{field}' is invalid: {}", joined));
+            }
+
+            ValidationErrorsKind::List(map) => {
+                for (index, errors) in map {
+                    str_errors.push(format!(
+                        "field '{field}' at index {index} is invalid ({})",
+                        extract_validation_error(errors)
+                    ));
+                }
+            }
+        }
+    }
+
+    str_errors.join(", ")
 }

--- a/src/types/mod_json.rs
+++ b/src/types/mod_json.rs
@@ -17,7 +17,7 @@ use super::models::{
     mod_gd_version::DetailedGDVersion,
 };
 
-const MAX_MOD_JSON_SIZE: u64 = 65536; // 64 KB
+const MAX_MOD_JSON_SIZE: u64 = 128 * 1024; // 128 KB
 const MAX_MARKDOWN_FILE_SIZE: u64 = 1048576; // 1 MB
 const MAX_MOD_ZIP_SIZE: u64 = 1024 * 1024 * 512; // 512 mb
 
@@ -500,6 +500,13 @@ impl ModJson {
         if self.id == "geode.loader" {
             return Err(ModZipError::InvalidModJson(
                 "Noooo you can't do that :(".to_string(),
+            ));
+        }
+
+        // check if name consists of printable chars
+        if !self.name.chars().all(|c| c.is_ascii_graphic() || c == ' ') {
+            return Err(ModZipError::InvalidModJson(
+                "Mod name contains non-printable characters".to_string(),
             ));
         }
 


### PR DESCRIPTION
* Avoid unzipping zip bombs (skip processing entirely if total uncompressed size >= 512mb)
* Cap sizes of mod.json and markdown files
* Validate that mod name consists of only printable characters
* Put reasonable length limits on a bunch of strings
* Add length limit to dev display names