### PR TITLE
Fix panic when using unlisted filter in /v1/mods

### DIFF
--- a/src/types/models/mod_entity.rs
+++ b/src/types/models/mod_entity.rs
@@ -354,15 +354,15 @@ impl Mod {
 
         let ret = records
             .into_iter()
-            .map(|x| {
-                let mut version = versions.remove(&x.id).unwrap();
+            .filter_map(|x| {
+                let mut version = versions.remove(&x.id)?;
                 version.gd = gd_versions.remove(&version.id).unwrap_or_default();
 
                 let devs = developers.remove(&x.id).unwrap_or_default();
                 let tags = tags.remove(&x.id).unwrap_or_default();
                 let links = links.iter().find(|link| link.mod_id == x.id).cloned();
 
-                Mod {
+                Some(Mod {
                     id: x.id,
                     repository: x.repository,
                     download_count: x.download_count.into(),
@@ -375,7 +375,7 @@ impl Mod {
                     about: None,
                     changelog: None,
                     links,
-                }
+                })
             })
             .collect();
         Ok(PaginatedData { data: ret, count })


### PR DESCRIPTION
So I'm not sure this is the best way to fix it, but basically the code here tries to get the latest accepted version for each mod, and if a mod has not a single accepted version, `get_latest_for_mods` simply won't include that ID, which leads to an unchecked unwrap and a panic. 

This PR instead just filters out such mods to avoid a panic. I don't think the unlisted filter is actually used anywhere, but it's still a good idea to not expose a panic url to the public