### PR TITLE
switch to mimalloc when using musl

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1512,6 +1512,7 @@ dependencies = [
  "futures",
  "image",
  "lzma-rust2",
+ "mimalloc",
  "moka",
  "regex",
  "reqwest",
@@ -2192,6 +2193,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
+name = "libmimalloc-sys"
+version = "0.1.49"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a45a52f43e1c16f667ccfe4dd8c85b7f7c204fd5e3bf46c5b0db9a5c3c0b8e9"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "libredox"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2332,6 +2342,15 @@ name = "memchr"
 version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
+
+[[package]]
+name = "mimalloc"
+version = "0.1.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d4139bb28d14ad1facf21d5eb8825051b326e172d216b39f6d31df53cc97862"
+dependencies = [
+ "libmimalloc-sys",
+]
 
 [[package]]
 name = "mime"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,3 +46,6 @@ utoipa-swagger-ui = { version = "9.0.2", features = ["actix-web"] }
 uuid = { version = "1.8", features = ["v4", "fast-rng", "macro-diagnostics"] }
 validator = { version = "0.20.0", features = ["derive"] }
 zip = "8.6.0"
+
+[target.'cfg(target_env = "musl")'.dependencies]
+mimalloc = "0.1.52"

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,6 +25,12 @@ mod storage;
 mod types;
 mod webhook;
 
+// Avoid musl's default allocator due to lackluster performance
+// https://nickb.dev/blog/default-musl-allocator-considered-harmful-to-performance
+#[cfg(target_env = "musl")]
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     logging::init();


### PR DESCRIPTION
Source: https://nickb.dev/blog/default-musl-allocator-considered-harmful-to-performance/

musl's memory allocator is crazy slow, in certain situations leading to slowdowns of up to 7x, especially when memory allocations happen often. Given that this is a web server, it's safe to assume this is the case.

Only include mimalloc when using musl, otherwise use the default allocator.