### PR TITLE
Potential vulnerability patches

### DIFF
--- a/src/auth/github.rs
+++ b/src/auth/github.rs
@@ -47,9 +47,11 @@ pub struct GithubErrorResponse {
     error_uri: String,
 }
 
+#[derive(Clone)]
 pub struct GithubClient {
     client_id: String,
     client_secret: String,
+    http_client: Client,
 }
 
 #[derive(Serialize)]
@@ -77,11 +79,16 @@ pub struct GitHubFetchedUser {
 }
 
 impl GithubClient {
-    pub fn new(client_id: String, client_secret: String) -> GithubClient {
+    pub fn new(client_id: String, client_secret: String, http_client: Client) -> GithubClient {
         GithubClient {
             client_id,
             client_secret,
+            http_client,
         }
+    }
+
+    pub fn client_id(&self) -> &str {
+        &self.client_id
     }
 
     pub async fn start_polling_auth(
@@ -98,7 +105,8 @@ impl GithubClient {
             }
         }
 
-        let res = Client::new()
+        let res = self
+            .http_client
             .post("https://github.com/login/device/code")
             .header("Accept", HeaderValue::from_static("application/json"))
             .basic_auth(&self.client_id, Some(&self.client_secret))
@@ -172,7 +180,8 @@ impl GithubClient {
             }
         };
 
-        let resp = Client::new()
+        let resp = self
+            .http_client
             .post("https://github.com/login/oauth/access_token")
             .header("Accept", HeaderValue::from_str("application/json").unwrap())
             .header(
@@ -203,7 +212,8 @@ impl GithubClient {
             .to_string())
     }
     pub async fn get_user(&self, token: &str) -> Result<GitHubFetchedUser, AuthenticationError> {
-        let resp = Client::new()
+        let resp = self
+            .http_client
             .get("https://api.github.com/user")
             .header("Accept", HeaderValue::from_str("application/json").unwrap())
             .header("User-Agent", "geode_index")
@@ -234,8 +244,8 @@ impl GithubClient {
         &self,
         token: &str,
     ) -> Result<GitHubFetchedUser, AuthenticationError> {
-        let client = Client::new();
-        let resp = client
+        let resp = self
+            .http_client
             .get("https://api.github.com/installation/repositories")
             .header("Accept", HeaderValue::from_str("application/json").unwrap())
             .header("User-Agent", "geode_index")

--- a/src/config.rs
+++ b/src/config.rs
@@ -7,6 +7,7 @@ use moka::future::Cache;
 use tokio::sync::mpsc::Sender;
 
 use crate::{
+    auth::github::GithubClient,
     dns::ValidateDnsResolver,
     endpoints::mods::IndexQueryParams,
     s3_worker::S3WorkerTask,
@@ -22,7 +23,7 @@ pub struct AppData {
     db: sqlx::postgres::PgPool,
     app_url: String,
     front_url: String,
-    github: GitHubClientData,
+    github_client: GithubClient,
     webhook_url: String,
     index_admin_webhook_url: String,
     static_storage: PublicDisk,
@@ -39,12 +40,6 @@ pub struct AppData {
     check_dns_http_client: reqwest::Client,
 
     s3_sender: OnceLock<Sender<S3WorkerTask>>,
-}
-
-#[derive(Clone)]
-pub struct GitHubClientData {
-    client_id: String,
-    client_secret: String,
 }
 
 pub async fn build_config() -> anyhow::Result<AppData> {
@@ -94,14 +89,17 @@ pub async fn build_config() -> anyhow::Result<AppData> {
         .timeout(Duration::from_secs(30))
         .build()?;
 
+    let http_client = reqwest::Client::builder()
+        .pool_max_idle_per_host(4)
+        .connect_timeout(Duration::from_secs(10))
+        .read_timeout(Duration::from_secs(30))
+        .build()?;
+
     Ok(AppData {
         db: pool,
         app_url: app_url.clone(),
         front_url,
-        github: GitHubClientData {
-            client_id: github_client,
-            client_secret: github_secret,
-        },
+        github_client: GithubClient::new(github_client, github_secret, http_client.clone()),
         webhook_url,
         index_admin_webhook_url,
         static_storage: PublicDisk::new(
@@ -119,24 +117,10 @@ pub async fn build_config() -> anyhow::Result<AppData> {
         port,
         debug,
         mods_cache,
-        http_client: reqwest::Client::builder()
-            .pool_max_idle_per_host(4)
-            .connect_timeout(Duration::from_secs(10))
-            .read_timeout(Duration::from_secs(30))
-            .build()?,
+        http_client,
         check_dns_http_client,
         s3_sender: OnceLock::new(),
     })
-}
-
-impl GitHubClientData {
-    pub fn client_id(&self) -> &str {
-        &self.client_id
-    }
-
-    pub fn client_secret(&self) -> &str {
-        &self.client_secret
-    }
 }
 
 impl AppData {
@@ -152,8 +136,8 @@ impl AppData {
         &self.front_url
     }
 
-    pub fn github(&self) -> &GitHubClientData {
-        &self.github
+    pub fn github_client(&self) -> &GithubClient {
+        &self.github_client
     }
 
     pub fn webhook_url(&self) -> &str {

--- a/src/endpoints/auth/github.rs
+++ b/src/endpoints/auth/github.rs
@@ -271,7 +271,7 @@ pub async fn github_token_login(
 
     let user = match client.get_user(&json.token).await {
         Err(_) => client.get_installation(&json.token).await.map_err(|e| {
-            tracing::error!(error = ?e, token = %json.token, "invalid access token");
+            tracing::error!(error = ?e, "invalid access token");
             ApiError::BadRequest("Invalid access token".to_owned())
         })?,
 

--- a/src/endpoints/auth/github.rs
+++ b/src/endpoints/auth/github.rs
@@ -11,7 +11,7 @@ use crate::database::repository::{
 };
 use crate::endpoints::ApiError;
 use crate::endpoints::auth::TokensResponse;
-use crate::{auth::github, types::api::ApiResponse};
+use crate::types::api::ApiResponse;
 
 #[derive(Deserialize, ToSchema)]
 struct PollParams {
@@ -46,10 +46,7 @@ pub async fn start_github_login(
     info: ConnectionInfo,
 ) -> Result<impl Responder, ApiError> {
     let mut pool = data.db().acquire().await?;
-    let client = github::GithubClient::new(
-        data.github().client_id().to_string(),
-        data.github().client_secret().to_string(),
-    );
+    let client = data.github_client();
 
     let Some(ip) = info.realip_remote_addr() else {
         return Err(ApiError::InternalError(
@@ -83,12 +80,13 @@ pub async fn start_github_web_login(data: web::Data<AppData>) -> Result<impl Res
     let mut pool = data.db().acquire().await?;
 
     let secret = github_web_logins::create_unique(&mut pool).await?;
+    let client = data.github_client();
 
     Ok(web::Json(ApiResponse {
         error: "".into(),
         payload: format!(
             "https://github.com/login/oauth/authorize?client_id={}&redirect_uri={}/login/github/callback&scope=read:user&state={}",
-            data.github().client_id(),
+            client.client_id(),
             data.front_url(),
             secret
         ),
@@ -124,11 +122,7 @@ pub async fn github_web_callback(
 
     github_web_logins::remove(parsed, &mut pool).await?;
 
-    let client = github::GithubClient::new(
-        data.github().client_id().to_string(),
-        data.github().client_secret().to_string(),
-    );
-
+    let client = data.github_client();
     let token = client
         .poll_github(&json.code, false, Some(data.front_url()))
         .await?;
@@ -207,10 +201,7 @@ pub async fn poll_github_login(
 
     let mut tx = pool.begin().await?;
 
-    let client = github::GithubClient::new(
-        data.github().client_id().to_string(),
-        data.github().client_secret().to_string(),
-    );
+    let client = data.github_client();
     github_login_attempts::poll_now(uuid, &mut tx).await?;
     let token = client.poll_github(&attempt.device_code, true, None).await?;
     github_login_attempts::remove(uuid, &mut tx).await?;
@@ -276,15 +267,12 @@ pub async fn github_token_login(
     json: web::Json<TokenLoginParams>,
     data: web::Data<AppData>,
 ) -> Result<impl Responder, ApiError> {
-    let client = github::GithubClient::new(
-        data.github().client_id().to_string(),
-        data.github().client_secret().to_string(),
-    );
+    let client = data.github_client();
 
     let user = match client.get_user(&json.token).await {
         Err(_) => client.get_installation(&json.token).await.map_err(|e| {
-            tracing::error!(error = ?e, "invalid access token");
-            ApiError::BadRequest(format!("Invalid access token: {}", json.token))
+            tracing::error!(error = ?e, token = %json.token, "invalid access token");
+            ApiError::BadRequest("Invalid access token".to_owned())
         })?,
 
         Ok(u) => u,

--- a/src/endpoints/loader.rs
+++ b/src/endpoints/loader.rs
@@ -175,7 +175,7 @@ pub async fn get_many(
             platform: query.platform,
             prerelease: query.prerelease.unwrap_or_default(),
         },
-        query.per_page.unwrap_or(10),
+        query.per_page.unwrap_or(10).min(50),
         query.page.unwrap_or(1),
         &mut pool,
     )

--- a/src/endpoints/mod.rs
+++ b/src/endpoints/mod.rs
@@ -3,6 +3,7 @@ use crate::{
     types::{api::ApiResponse, models::mod_gd_version::PlatformParseError},
 };
 use actix_web::{HttpResponse, http::StatusCode};
+use validator::{ValidationError, ValidationErrors};
 
 pub mod auth;
 pub mod deprecations;
@@ -76,4 +77,89 @@ impl actix_web::ResponseError for ApiError {
     fn error_response(&self) -> HttpResponse<actix_web::body::BoxBody> {
         HttpResponse::build(self.status_code()).json(self.as_response())
     }
+}
+
+// validator errors
+
+impl From<ValidationError> for ApiError {
+    fn from(value: ValidationError) -> Self {
+        ApiError::BadRequest(format_validation_error(&value))
+    }
+}
+
+impl From<ValidationErrors> for ApiError {
+    fn from(value: ValidationErrors) -> Self {
+        ApiError::BadRequest(format_validation_errors(&value))
+    }
+}
+
+pub fn format_validation_error(e: &validator::ValidationError) -> String {
+    if let Some(msg) = &e.message {
+        return msg.to_string();
+    }
+
+    match e.code.as_ref() {
+        "length" => {
+            let min = e
+                .params
+                .get("min")
+                .and_then(|v| v.as_u64())
+                .map(|v| v.to_string());
+
+            let max = e
+                .params
+                .get("max")
+                .and_then(|v| v.as_u64())
+                .map(|v| v.to_string());
+
+            match (min, max) {
+                (Some(min), Some(max)) => {
+                    format!("length must be between {min} and {max} characters")
+                }
+                (Some(min), None) => format!("length must be at least {min} characters"),
+                (None, Some(max)) => format!("length must be at most {max} characters"),
+                (None, None) => "invalid length".to_string(),
+            }
+        }
+
+        e => e.to_owned(),
+    }
+}
+
+pub fn format_validation_errors(e: &validator::ValidationErrors) -> String {
+    use validator::ValidationErrorsKind;
+
+    let mut str_errors = Vec::new();
+
+    for (field, err) in e.errors() {
+        match err {
+            ValidationErrorsKind::Struct(s) => {
+                str_errors.push(format!(
+                    "field '{field}' is invalid ({})",
+                    format_validation_errors(s)
+                ));
+            }
+
+            ValidationErrorsKind::Field(errors) => {
+                let joined = errors
+                    .iter()
+                    .map(format_validation_error)
+                    .collect::<Vec<_>>()
+                    .join(", ");
+
+                str_errors.push(format!("field '{field}' is invalid: {}", joined));
+            }
+
+            ValidationErrorsKind::List(map) => {
+                for (index, errors) in map {
+                    str_errors.push(format!(
+                        "field '{field}' at index {index} is invalid ({})",
+                        format_validation_errors(errors)
+                    ));
+                }
+            }
+        }
+    }
+
+    str_errors.join(", ")
 }

--- a/src/endpoints/mod_version_submissions.rs
+++ b/src/endpoints/mod_version_submissions.rs
@@ -17,6 +17,7 @@ use crate::webhook::discord::DiscordWebhook;
 use actix_multipart::Multipart;
 use actix_web::{HttpResponse, Responder, delete, get, post, put, web};
 use futures::StreamExt;
+use image::{DynamicImage, ImageReader, Limits};
 use serde::Deserialize;
 use sqlx::{Acquire, PgConnection};
 use std::collections::HashMap;
@@ -839,7 +840,7 @@ pub async fn upload_attachments(
             images
                 .into_iter()
                 .map(|raw| {
-                    let img = image::load_from_memory(&raw)
+                    let img = safe_image_decode(&raw)
                         .map_err(|e| ApiError::BadRequest(format!("Invalid image: {e}")))?;
                     let mut webp_bytes: Vec<u8> = Vec::new();
                     img.write_to(
@@ -998,4 +999,15 @@ pub async fn delete_attachment(
     }
 
     Ok(HttpResponse::NoContent())
+}
+
+fn safe_image_decode(raw: &[u8]) -> Result<DynamicImage, image::ImageError> {
+    let mut limits = Limits::default();
+    limits.max_image_width = Some(2048);
+    limits.max_image_height = Some(2048);
+    limits.max_alloc = Some(64 * 1024 * 1024);
+
+    let mut reader = ImageReader::new(std::io::Cursor::new(raw));
+    reader.limits(limits);
+    reader.with_guessed_format()?.decode()
 }

--- a/src/endpoints/mod_versions.rs
+++ b/src/endpoints/mod_versions.rs
@@ -4,6 +4,7 @@ use actix_web::{HttpResponse, Responder, dev::ConnectionInfo, get, post, put, we
 use serde::Deserialize;
 use sqlx::{Acquire, types::ipnetwork::IpNetwork};
 use utoipa::{IntoParams, ToSchema};
+use validator::Validate;
 
 use crate::config::AppData;
 use crate::database::repository::{
@@ -44,8 +45,9 @@ pub struct GetOnePath {
     version: String,
 }
 
-#[derive(Deserialize, ToSchema)]
+#[derive(Deserialize, ToSchema, Validate)]
 pub struct CreateQueryParams {
+    #[validate(length(max = 1024))]
     download_link: String,
 }
 
@@ -310,6 +312,8 @@ pub async fn create_version(
     payload: web::Json<CreateQueryParams>,
     auth: Auth,
 ) -> Result<impl Responder, ApiError> {
+    payload.validate()?;
+
     let dev = auth.developer()?;
     let mut pool = data.db().acquire().await?;
 

--- a/src/endpoints/mod_versions.rs
+++ b/src/endpoints/mod_versions.rs
@@ -123,7 +123,7 @@ pub async fn get_version_index(
         mod_version::IndexQuery {
             mod_id: path.id.clone(),
             page: query.page.unwrap_or(1),
-            per_page: query.per_page.unwrap_or(10),
+            per_page: query.per_page.unwrap_or(10).min(50),
             compare,
             gd: query.gd,
             platforms,

--- a/src/endpoints/mods.rs
+++ b/src/endpoints/mods.rs
@@ -31,6 +31,8 @@ use serde::Serialize;
 use sqlx::Acquire;
 use utoipa::{IntoParams, ToSchema};
 
+const MAX_UPDATE_BATCH_SIZE: usize = 200;
+
 #[derive(Deserialize, Default, Hash, Eq, PartialEq, ToSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum IndexSortType {
@@ -364,6 +366,7 @@ pub async fn get_mod_updates(
     let ids = query
         .ids
         .split(';')
+        .take(MAX_UPDATE_BATCH_SIZE)
         .map(String::from)
         .collect::<Vec<String>>();
 

--- a/src/endpoints/mods.rs
+++ b/src/endpoints/mods.rs
@@ -30,6 +30,7 @@ use serde::Deserialize;
 use serde::Serialize;
 use sqlx::Acquire;
 use utoipa::{IntoParams, ToSchema};
+use validator::Validate;
 
 const MAX_UPDATE_BATCH_SIZE: usize = 200;
 
@@ -65,8 +66,9 @@ pub struct IndexQueryParams {
     pub status: Option<ModVersionStatusEnum>,
 }
 
-#[derive(Deserialize, ToSchema)]
+#[derive(Deserialize, ToSchema, Validate)]
 pub struct CreateQueryParams {
+    #[validate(length(max = 1024))]
     download_link: String,
 }
 
@@ -217,6 +219,8 @@ pub async fn create(
     payload: web::Json<CreateQueryParams>,
     auth: Auth,
 ) -> Result<impl Responder, ApiError> {
+    payload.validate()?;
+
     let dev = auth.developer()?;
     let mut pool = data.db().acquire().await?;
     let bytes = mod_zip::download_mod(

--- a/src/endpoints/mods.rs
+++ b/src/endpoints/mods.rs
@@ -222,7 +222,6 @@ pub async fn create(
     payload.validate()?;
 
     let dev = auth.developer()?;
-    let mut pool = data.db().acquire().await?;
     let bytes = mod_zip::download_mod(
         data.check_dns_http_client(),
         &payload.download_link,
@@ -232,6 +231,7 @@ pub async fn create(
     let json = ModJson::from_zip(&bytes, &payload.download_link, false)?;
     json.validate()?;
 
+    let mut pool = data.db().acquire().await?;
     let existing: Option<Mod> = mods::get_one(&json.id, false, &mut pool).await?;
 
     if json.id.starts_with("geode.") && !dev.admin {

--- a/src/endpoints/stats.rs
+++ b/src/endpoints/stats.rs
@@ -19,6 +19,6 @@ pub async fn get_stats(data: web::Data<AppData>) -> Result<impl Responder, ApiEr
     let mut pool = data.db().acquire().await?;
     Ok(web::Json(ApiResponse {
         error: "".into(),
-        payload: Stats::get_cached(&mut pool).await?,
+        payload: Stats::get_cached(&mut pool, data.http_client()).await?,
     }))
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,5 @@
 use crate::openapi::ApiDoc;
 use crate::types::api;
-use actix_cors::Cors;
 use actix_web::{
     App, HttpServer,
     web::{self, QueryConfig},
@@ -65,13 +64,6 @@ async fn main() -> anyhow::Result<()> {
             .app_data(QueryConfig::default().error_handler(api::query_error_handler))
             .service(
                 SwaggerUi::new("/swagger/{_:.*}").url("/swagger/openapi.json", openapi.clone()),
-            )
-            .wrap(
-                Cors::default()
-                    .allow_any_origin()
-                    .allowed_methods(vec!["GET", "HEAD"])
-                    .allow_any_header()
-                    .max_age(3600),
             )
             .wrap(tracing_actix_web::TracingLogger::default());
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -71,7 +71,6 @@ async fn main() -> anyhow::Result<()> {
                     .allow_any_origin()
                     .allowed_methods(vec!["GET", "POST", "PUT", "PATCH", "DELETE", "HEAD"])
                     .allow_any_header()
-                    .supports_credentials()
                     .max_age(3600),
             )
             .wrap(tracing_actix_web::TracingLogger::default());

--- a/src/main.rs
+++ b/src/main.rs
@@ -69,7 +69,7 @@ async fn main() -> anyhow::Result<()> {
             .wrap(
                 Cors::default()
                     .allow_any_origin()
-                    .allowed_methods(vec!["GET", "POST", "PUT", "PATCH", "DELETE", "HEAD"])
+                    .allowed_methods(vec!["GET", "HEAD"])
                     .allow_any_header()
                     .max_age(3600),
             )

--- a/src/mod_zip.rs
+++ b/src/mod_zip.rs
@@ -48,7 +48,8 @@ pub fn extract_mod_logo<R: Read>(file: &mut ZipFile<R>) -> Result<Vec<u8>, ModZi
     }
 
     let mut logo: Vec<u8> = Vec::with_capacity(file.size() as usize);
-    file.read_to_end(&mut logo)
+    file.take(file.size())
+        .read_to_end(&mut logo)
         .inspect_err(|e| tracing::error!("logo.png read fail: {}", e))?;
 
     let mut reader = BufReader::new(Cursor::new(logo));

--- a/src/storage/local.rs
+++ b/src/storage/local.rs
@@ -11,6 +11,17 @@ impl LocalBackend {
             base_path: base_path.into(),
         }
     }
+
+    fn safe_join(&self, suffix: &str) -> Result<PathBuf, StorageError> {
+        let path = self.base_path.join(suffix);
+        if path.starts_with(&self.base_path) {
+            Ok(path)
+        } else {
+            Err(StorageError::Other(
+                "Attempted accessing a path outside storage directory".to_owned(),
+            ))
+        }
+    }
 }
 
 impl StorageBackend for LocalBackend {
@@ -20,7 +31,7 @@ impl StorageBackend for LocalBackend {
         data: &'a [u8],
     ) -> BoxFuture<'a, StorageResult<()>> {
         Box::pin(async move {
-            let path = self.base_path.join(relative_path);
+            let path = self.safe_join(relative_path)?;
             if let Some(parent) = path.parent() {
                 tokio::fs::create_dir_all(parent).await?;
             }
@@ -31,7 +42,7 @@ impl StorageBackend for LocalBackend {
 
     fn read<'a>(&'a self, path: &'a str) -> BoxFuture<'a, StorageResult<Vec<u8>>> {
         Box::pin(async move {
-            let path = self.base_path.join(path);
+            let path = self.safe_join(path)?;
             match tokio::fs::read(path).await {
                 Ok(data) => Ok(data),
                 Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(vec![]),
@@ -43,14 +54,14 @@ impl StorageBackend for LocalBackend {
 
     fn exists<'a>(&'a self, path: &'a str) -> BoxFuture<'a, StorageResult<bool>> {
         Box::pin(async move {
-            let path = self.base_path.join(path);
+            let path = self.safe_join(path)?;
             Ok(tokio::fs::metadata(path).await.is_ok())
         })
     }
 
     fn delete<'a>(&'a self, path: &'a str) -> BoxFuture<'a, StorageResult<()>> {
         Box::pin(async move {
-            let path = self.base_path.join(path);
+            let path = self.safe_join(path)?;
             match tokio::fs::remove_file(path).await {
                 Ok(()) => Ok(()),
                 Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),

--- a/src/types/mod_json.rs
+++ b/src/types/mod_json.rs
@@ -8,6 +8,7 @@ use serde::Deserialize;
 use validator::{Validate, ValidationError};
 use zip::read::ZipFile;
 
+use crate::endpoints::format_validation_errors;
 use crate::mod_zip::{self, ModZipError};
 
 use super::models::{
@@ -244,7 +245,7 @@ impl ModJson {
                     }
 
                     json.about = Some(
-                        parse_zip_entry_to_str(&mut file)
+                        parse_zip_entry_to_str(&mut file, MAX_MARKDOWN_FILE_SIZE)
                             .inspect_err(|e| {
                                 tracing::error!("Failed to parse about.md for mod: {e}")
                             })
@@ -261,7 +262,7 @@ impl ModJson {
                     }
 
                     json.changelog = Some(
-                        parse_zip_entry_to_str(&mut file)
+                        parse_zip_entry_to_str(&mut file, MAX_MARKDOWN_FILE_SIZE)
                             .inspect_err(|e| tracing::error!("Failed to parse changelog.md: {e}"))
                             .map_err(|e| {
                                 ModZipError::InvalidModJson(format!(
@@ -502,7 +503,7 @@ impl ModJson {
     pub fn validate(&self) -> Result<(), ModZipError> {
         if let Err(e) = <Self as Validate>::validate(self) {
             tracing::warn!("mod.json validation error: {e}");
-            let useful_error = extract_validation_error(&e);
+            let useful_error = format_validation_errors(&e);
             return Err(ModZipError::InvalidModJson(format!(
                 "validation error: {useful_error}"
             )));
@@ -616,9 +617,9 @@ impl ModJson {
     }
 }
 
-fn parse_zip_entry_to_str<R: Read>(file: &mut ZipFile<R>) -> Result<String, String> {
+fn parse_zip_entry_to_str<R: Read>(file: &mut ZipFile<R>, limit: u64) -> Result<String, String> {
     let mut string: String = String::from("");
-    match file.read_to_string(&mut string) {
+    match file.take(limit).read_to_string(&mut string) {
         Ok(_) => Ok(string),
         Err(e) => {
             tracing::error!("{}", e);
@@ -727,75 +728,4 @@ fn validate_vec_string(vec: &Vec<String>) -> Result<(), ValidationError> {
         }
     }
     Ok(())
-}
-
-fn map_field_error(e: &validator::ValidationError) -> String {
-    if let Some(msg) = &e.message {
-        return msg.to_string();
-    }
-
-    match e.code.as_ref() {
-        "length" => {
-            let min = e
-                .params
-                .get("min")
-                .and_then(|v| v.as_u64())
-                .map(|v| v.to_string());
-
-            let max = e
-                .params
-                .get("max")
-                .and_then(|v| v.as_u64())
-                .map(|v| v.to_string());
-
-            match (min, max) {
-                (Some(min), Some(max)) => {
-                    format!("length must be between {min} and {max} characters")
-                }
-                (Some(min), None) => format!("length must be at least {min} characters"),
-                (None, Some(max)) => format!("length must be at most {max} characters"),
-                (None, None) => "invalid length".to_string(),
-            }
-        }
-
-        e => e.to_owned(),
-    }
-}
-
-fn extract_validation_error(e: &validator::ValidationErrors) -> String {
-    use validator::ValidationErrorsKind;
-
-    let mut str_errors = Vec::new();
-
-    for (field, err) in e.errors() {
-        match err {
-            ValidationErrorsKind::Struct(s) => {
-                str_errors.push(format!(
-                    "field '{field}' is invalid ({})",
-                    extract_validation_error(s)
-                ));
-            }
-
-            ValidationErrorsKind::Field(errors) => {
-                let joined = errors
-                    .iter()
-                    .map(map_field_error)
-                    .collect::<Vec<_>>()
-                    .join(", ");
-
-                str_errors.push(format!("field '{field}' is invalid: {}", joined));
-            }
-
-            ValidationErrorsKind::List(map) => {
-                for (index, errors) in map {
-                    str_errors.push(format!(
-                        "field '{field}' at index {index} is invalid ({})",
-                        extract_validation_error(errors)
-                    ));
-                }
-            }
-        }
-    }
-
-    str_errors.join(", ")
 }

--- a/src/types/models/stats.rs
+++ b/src/types/models/stats.rs
@@ -30,20 +30,27 @@ pub struct Stats {
 
 impl Stats {
     #[tracing::instrument(skip_all)]
-    pub async fn get_cached(pool: &mut PgConnection) -> Result<Stats, ApiError> {
+    pub async fn get_cached(
+        pool: &mut PgConnection,
+        http_client: &Client,
+    ) -> Result<Stats, ApiError> {
         let mod_stats = Mod::get_stats(&mut *pool).await?;
         Ok(Stats {
             total_mod_count: mod_stats.total_count,
             total_mod_downloads: mod_stats.total_downloads,
             total_registered_developers: developers::index_count(None, &mut *pool).await?,
-            total_geode_downloads: Self::get_latest_github_release_download_count(&mut *pool)
-                .await?,
+            total_geode_downloads: Self::get_latest_github_release_download_count(
+                &mut *pool,
+                http_client,
+            )
+            .await?,
         })
     }
 
     #[tracing::instrument(skip_all)]
     async fn get_latest_github_release_download_count(
         pool: &mut PgConnection,
+        http_client: &Client,
     ) -> Result<i64, ApiError> {
         // If release stats were fetched less than a day ago, just use cached stats
         if let Ok((cache_time, total_download_count)) = sqlx::query!(
@@ -61,7 +68,7 @@ impl Stats {
         }
 
         // Fetch latest stats
-        let new = Self::fetch_github_release_stats().await?;
+        let new = Self::fetch_github_release_stats(http_client).await?;
         sqlx::query!(
             "INSERT INTO github_loader_release_stats (total_download_count, latest_loader_version)
             VALUES ($1, $2)",
@@ -74,9 +81,8 @@ impl Stats {
         Ok(new.0)
     }
 
-    async fn fetch_github_release_stats() -> Result<(i64, String), ApiError> {
-        let client = Client::new();
-        let resp = client
+    async fn fetch_github_release_stats(http_client: &Client) -> Result<(i64, String), ApiError> {
+        let resp = http_client
             .get("https://api.github.com/repos/geode-sdk/geode/releases")
             .header("Accept", HeaderValue::from_str("application/json").unwrap())
             .header("User-Agent", "geode_index")

--- a/src/types/models/tag.rs
+++ b/src/types/models/tag.rs
@@ -63,6 +63,7 @@ impl Tag {
     pub async fn parse_tags(tags: &str, pool: &mut PgConnection) -> Result<Vec<i32>, ApiError> {
         let tags = tags
             .split(',')
+            .take(50)
             .map(|t| t.trim().to_lowercase())
             .collect::<Vec<String>>();
 


### PR DESCRIPTION
If you can't beat them, join them.. so this is an AI powered PR to fix potential security holes & DoS vectors in the index :D

(note: AI only used to find, not fix)

changes:
* GitHub token no longer logged in error messages
* `image::load_from_memory` replaced with a safer version that respects limits
* Download URL length is now capped to 1024 chars to avoid anything funny
* Updates endpoint accepts max 200 mods (client already respects this limit)
* CORS changed to not allow credentials (pls verify this change is correct)
* Some limits (like `per_page` values) are now clamped
* Order of operations is changed in one place to avoid borrowing a pooled DB connection and keeping it idle for a period of time (e.g. during a mod download)
* `LocalStorage` changed to not allow path traversal (future proofing, impossible in current code)
* Zip file reading changed to call `take` and not read more bytes than advertised in the file metadata. I don't know if this is a true vulnerability, but after a quick read of `zip`'s source code, I could not find it clearly enforcing the limit, so this validation might not be pointless

non-security changes:
* Why was the `GithubClient` struct created on demand each time? Why was a `reqwest::Client` created on demand on every operation in that client? We may never know.
* .. plus use the shared http client in a few more places